### PR TITLE
Update terraform-aws-util module to latest version

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -4,6 +4,8 @@ name: terraform
 
 on:
   push:
+#   branches:
+#     - master
   pull_request:
 
 jobs:
@@ -18,7 +20,10 @@ jobs:
 
       - name: terraform setup
         uses: hashicorp/setup-terraform@v3
+      #   cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
       - name: run make
+      # env:
+      #   TOKEN: ${{ secrets.TOKEN }}
         run: |
           make all

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ test: .terraform
 	# DO put a badge in top-level README.md
 	grep -q "\[\!\[Terraform actions status\]([^)]*$(REPO)/workflows/terraform/badge.svg)\]([^)]*$(REPO)/actions)" README.md
 	# Do NOT use ?ref= in source lines in a README.md!
-	! grep 'source\s*=.*?ref=' *.tf README.md
+	! grep 'source\s*=.*?ref=' README.md
 	# Do NOT start a source line with git::
 	! grep 'source\s*=\s*"git::' *.tf README.md
 	# Do NOT use .git in a source line

--- a/data.tf
+++ b/data.tf
@@ -1,7 +1,7 @@
 # FIXME: Replace reference to branch with reference to tagged version.
 
 module "get-subnets" {
-  source = "github.com/techservicesillinois/terraform-aws-util//modules/get-subnets?ref=v3.0.4"
+  source = "github.com/techservicesillinois/terraform-aws-util//modules/get-subnets?ref=v3.0.5"
 
   count = local.subnet_type != "" ? 1 : 0
 


### PR DESCRIPTION
The legacy 'tier' variable in the terraform-aws-util module has been retired. Accordingly, bump this module to refer to latest version of terraform-aws-util.